### PR TITLE
Add support for GNOME 42

### DIFF
--- a/src/metadata.json
+++ b/src/metadata.json
@@ -8,7 +8,8 @@
     "3.36",
     "3.38",
     "40",
-    "41"
+    "41",
+    "42"
   ],
   "url": "https://github.com/Zefty/AutoNightLight",
   "uuid": "autonightlight@zefty.github.io",

--- a/src/ui/prefs/prefs_gtk3.js
+++ b/src/ui/prefs/prefs_gtk3.js
@@ -3,7 +3,7 @@ const {Gio, GObject, Gtk, GLib} = imports.gi;
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
 
-const AutoNightLightPrefsGTK3 = new GObject.Class({
+var AutoNightLightPrefsGTK3 = new GObject.Class({
     Name: 'AutoNightLightPrefsGTK3',
     GTypeName: 'AutoNightLightPrefsGTK3',
     Extends: Gtk.Box,

--- a/src/ui/prefs/prefs_gtk4.js
+++ b/src/ui/prefs/prefs_gtk4.js
@@ -3,7 +3,7 @@ const {Gio, GObject, Gtk, GLib} = imports.gi;
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
 
-const AutoNightLightPrefsGTK4 = new GObject.Class({
+var AutoNightLightPrefsGTK4 = new GObject.Class({
     Name: 'AutoNightLightPrefsGTK4',
     GTypeName: 'AutoNightLightPrefsGTK4',
     Extends: Gtk.Box,


### PR DESCRIPTION
Currently, the extension is unusable on GNOME 42 since opening the preferences menu fails with the error message "PrefsGTK4 is not a constructor". The system log gives a helpful hint:
> Aug 14 17:28:58 max-new-laptop gjs[184130]: Some code accessed the property 'AutoNightLightPrefsGTK4' on the module 'prefs_gtk4'. That property was defined with 'let' or 'const' inside the module. This was previously supported, but is not correct according to the ES6 standard. Any symbols to be exported from a module must be defined with 'var'. The property access will work as previously for the time being, but please fix your code anyway.

Following this suggestion makes the extension work perfectly.